### PR TITLE
Add Basic WireMock Theme as a PoC

### DIFF
--- a/docs/css/README.md
+++ b/docs/css/README.md
@@ -1,0 +1,4 @@
+# WireMock Theme for MkDocs
+
+Experimental theme which overrides some bits like CSS.
+It is not a standalone or fancy theme, at least for now.

--- a/docs/css/wiremock.css
+++ b/docs/css/wiremock.css
@@ -1,0 +1,43 @@
+:root {
+    --wm-blue: #0FB2EF;
+    --wm-orange: #FF9505;
+    --wm-light-blue: #F0F5FF;
+  }
+
+.wm-button {
+    height: 100%;
+    right: 0;
+    padding: 0 0.5rem;
+    outline: none;
+    height: 40px;
+    background-color: var(--wm-light-blue);
+    border: 3px solid var(--wm-blue);
+    border-radius: 5px;
+    font-weight: bold;
+    color: var(--wm-blue);
+    cursor: pointer;
+}
+
+.wm-left {
+    float: left;
+}
+
+.wy-side-nav-search {
+    background-color: var(--wm-blue);
+}
+
+.wy-menu-vertical header, .wy-menu-vertical p.caption {
+    color: var(--wm-blue);
+}
+
+h2 {
+    color: var(--wm-blue); 
+}
+
+h3 {
+    color: var(--wm-blue); 
+}
+
+h4 {
+    color: var(--wm-blue); 
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,9 @@ theme:
   name: readthedocs
   highlightjs: true
 
+extra_css:
+  - css/wiremock.css
+
 plugins:
   - search
   - multirepo:


### PR DESCRIPTION
Just shows how we change colors of the theme to WireMock Blue

![image](https://github.com/wiremock/components-site/assets/3000480/e242ad3a-2d37-4b67-8ec4-9124138bb9ea)
